### PR TITLE
Metadata filename revision suffix, compare view & list/unsaved refinements

### DIFF
--- a/v4/tools/WebTool/CIEmetaDB.html
+++ b/v4/tools/WebTool/CIEmetaDB.html
@@ -221,7 +221,7 @@
 
 /* ---------- constants ---------- */
 const APP = {
-  VERSION: "1.6.0",
+  VERSION: "1.7.0",
   DB_SCHEMA_NAME: "CIEmetaDB",
   DB_SCHEMA_VERSION: 1,
   DOI_PREFIX: "10.25039/CIE.DS.",
@@ -503,6 +503,33 @@ function diffPatch(a, b, base){
   return ops;
 }
 function esc6902(k){ return String(k).replace(/~/g,"~0").replace(/\//g,"~1"); }
+/* granular field diff: like diffPatch but recurses into arrays by index so a single
+   changed element yields a precise leaf path (e.g. /checksums/1/checksum) instead of a
+   whole-array replace. Used by the "Compare with file" view. */
+function deepDiff(a, b, base){
+  base = base||"";
+  const ops=[];
+  const isObj=x=>x&&typeof x==="object"&&!Array.isArray(x);
+  if(isObj(a)&&isObj(b)){
+    for(const k of Object.keys(a)){ if(!(k in b)) ops.push({op:"remove",path:base+"/"+esc6902(k)}); }
+    for(const k of Object.keys(b)){
+      const p=base+"/"+esc6902(k);
+      if(!(k in a)) ops.push({op:"add",path:p,value:clone(b[k])});
+      else ops.push(...deepDiff(a[k],b[k],p));
+    }
+  }else if(Array.isArray(a)&&Array.isArray(b)){
+    const n=Math.max(a.length,b.length);
+    for(let i=0;i<n;i++){
+      const p=base+"/"+i;
+      if(i>=a.length) ops.push({op:"add",path:p,value:clone(b[i])});
+      else if(i>=b.length) ops.push({op:"remove",path:p});
+      else ops.push(...deepDiff(a[i],b[i],p));
+    }
+  }else{
+    if(canonical(a)!==canonical(b)) ops.push({op:"replace",path:base,value:clone(b)});
+  }
+  return ops;
+}
 /* reconstruct payload at revision rev (1-based) from history forward patches */
 function reconstruct(history, rev){
   let doc={};
@@ -1107,6 +1134,7 @@ function renderDetail(){
       <button class="ghost" id="btnRevert">Revert</button>
       <button class="ghost" id="btnGenDoi">Update DOI</button>
       <button class="ghost" id="btnRevertDefaults">Revert to defaults</button>
+      <button class="ghost" id="btnCompareFile">Compare with file&hellip;</button>
       <button class="ghost" id="btnValidateCsv">Validate against CSV&hellip;</button>
       <button class="ghost" id="btnDupe">Duplicate</button>
       <button class="ghost" id="btnExportOne">Export Metadata file</button>
@@ -1132,6 +1160,7 @@ function renderDetail(){
   el("btnDupe").onclick=()=>duplicateEntry(e);
   el("btnExportOne").onclick=()=>exportDataCiteFiles([e]);
   el("btnExportCrossref").onclick=()=>exportCrossrefXml(e);
+  el("btnCompareFile").onclick=()=>openCompareDialog(e);
   el("btnDelete").onclick=()=>deleteEntry(e);
   if(editDirty) el("saveState").textContent="● unsaved";
 
@@ -2022,6 +2051,92 @@ function openImportConflictDialog(conflicts, added){
   modal("Resolve import DOI conflicts",body,[mkBtn("Skip remaining","ghost",finish)]);
 }
 
+/* Read-only comparison of a database entry against an external metadata JSON file.
+   Loads a file, diffs every field against the saved entry payload, shows the
+   differences. Never imports or modifies anything. */
+function openCompareDialog(e){
+  pickFile(".json,application/json", async (f)=>{
+    let obj;
+    try{ obj=JSON.parse(await f.text()); }
+    catch(err){ toast("Invalid JSON file","err"); return; }
+    // resolve which object holds the metadata payload
+    if(obj && (obj.dbSchemaName===APP.DB_SCHEMA_NAME || Array.isArray(obj.entries))){
+      toast("That is a database file — pick a single metadata file","err"); return;
+    }
+    let payload = (obj && obj.payload && obj.entryId) ? obj.payload : obj;
+    if(!payload || typeof payload!=="object"){ toast("File does not contain a metadata object","err"); return; }
+
+    const body=document.createElement("div");
+
+    // header line
+    const hd=document.createElement("p"); hd.className="hint";
+    hd.innerHTML=`Comparing database entry <b>${esc(entryTitle(e))}</b> `+
+      `(rev ${e.rev}${entryDoi(e)?`, <span class="mono">${esc(entryDoi(e))}</span>`:""}) `+
+      `with file <b>${esc(f.name)}</b>.`;
+    body.appendChild(hd);
+
+    // soft identity check — warn but still compare
+    const fileDoi = payload.identifier && payload.identifier.identifier;
+    const fileFn = (payload.alternateIdentifiers||[]).filter(x=>x&&x.alternateIdentifierType==="fileName").map(x=>x.alternateIdentifier)[0];
+    const mism=[];
+    if(entryDoi(e) && fileDoi && entryDoi(e)!==fileDoi) mism.push(`DOI (entry: ${entryDoi(e)} · file: ${fileDoi})`);
+    if(entryFilename(e) && fileFn && entryFilename(e)!==fileFn) mism.push(`fileName (entry: ${entryFilename(e)} · file: ${fileFn})`);
+    if(mism.length){
+      const w=document.createElement("div"); w.className="warnrow";
+      w.textContent="⚠ This file does not appear to describe the same dataset — mismatched "+mism.join("; ")+". Comparing anyway.";
+      body.appendChild(w);
+    }
+
+    // informational schema check on the file
+    try{
+      const errs=validate(payload, CIE_SCHEMA);
+      if(errs && errs.length){
+        const v=document.createElement("p"); v.className="hint";
+        v.style.color="var(--warn)";
+        v.textContent=`Note: the file has ${errs.length} schema issue(s) (comparison still shown).`;
+        body.appendChild(v);
+      }
+    }catch(_){}
+
+    // field-by-field diff (all metadata fields, granular into arrays).
+    // metadataRevision is internal revision bookkeeping (not part of the DataCite
+    // metadata and absent from exported files), so it is excluded from the field diff;
+    // it remains visible in the raw side-by-side below.
+    const A=clone(e.payload), B=clone(payload);
+    delete A.metadataRevision; delete B.metadataRevision;
+    const ops=deepDiff(A, B, "");
+    if(ops.length===0){
+      const ok=document.createElement("div"); ok.className="val-ok";
+      ok.textContent="✓ No differences — the file matches this entry's metadata.";
+      body.appendChild(ok);
+    }else{
+      const sum=document.createElement("p"); sum.className="hint";
+      sum.innerHTML=`<b>${ops.length}</b> field difference(s). Legend: `+
+        `<span class="op-replace">~ changed</span> (database → file), `+
+        `<span class="op-add">+ only in file</span>, `+
+        `<span class="op-remove">− only in database</span>.`;
+      body.appendChild(sum);
+      const box=document.createElement("div"); box.className="diff";
+      box.innerHTML=renderDiff(ops, 2, e.payload);
+      body.appendChild(box);
+    }
+
+    // raw side-by-side for full context
+    function payloadBox(title,p){
+      const d=document.createElement("div"); d.className="conflict";
+      d.innerHTML=`<h4>${esc(title)}</h4>`;
+      const s=document.createElement("div"); s.className="side"; const pre=document.createElement("pre");
+      pre.textContent=JSON.stringify(p,null,1); s.appendChild(pre); d.appendChild(s); return d;
+    }
+    const cols=document.createElement("div"); cols.className="cols2";
+    cols.appendChild(payloadBox(`Database entry (rev ${e.rev})`, e.payload));
+    cols.appendChild(payloadBox("File", payload));
+    body.appendChild(cols);
+
+    modal("Compare with metadata file", body, [mkBtn("Close","ghost",closeModal)]);
+  });
+}
+
 /* Import/Merge dialog: aggregate DB merge OR datacite files */
 function openImportDialog(){
   const body=document.createElement("div");
@@ -2556,6 +2671,24 @@ function openHelpDialog(){
     </ul>
     <p style="margin:4px 0"><b>Validate the generated XML</b> with the Crossref deposit parser:<br>
       <a href="https://data.crossref.org/reports/parser.html" target="_blank" rel="noopener noreferrer">https://data.crossref.org/reports/parser.html</a></p>
+
+    <h4>Compare with an external metadata file <span class="kv">(new)</span></h4>
+    <p style="margin:4px 0">The per-entry <b>Compare with file…</b> button (entry action bar, next to
+      <b>Revert to defaults</b>) checks the selected database entry against an external
+      <code>*.csv_metadata.json</code> file — useful to see whether a published or exported file still
+      matches what the database holds. It is <b>read-only</b>: nothing is imported or changed.</p>
+    <ul>
+      <li>Pick a single metadata file; <b>every field is compared</b> and the differences are listed
+        field by field (arrays are compared element by element, so a single changed value — e.g.
+        <span class="mono">/checksums/1/checksum</span> — is pinpointed rather than shown as a whole-array change).</li>
+      <li>Colours follow the History diff: <span class="op-replace">~ changed</span> (database → file),
+        <span class="op-add">+ only in file</span>, <span class="op-remove">− only in database</span>.
+        A green banner confirms when there are <b>no differences</b>.</li>
+      <li>If the file's DOI or file name does not match the entry, a warning is shown but the comparison
+        still runs. The two payloads are also shown raw, side by side, for context.</li>
+      <li>The bookkeeping <span class="mono">metadataRevision</span> field is excluded from the field
+        comparison (exported files do not carry it), but remains visible in the raw side-by-side view.</li>
+    </ul>
 
     <h4>Reference links</h4>
     <ul>

--- a/v4/tools/WebTool/CIEmetaDB.html
+++ b/v4/tools/WebTool/CIEmetaDB.html
@@ -43,7 +43,7 @@
   input,select,textarea{font:inherit;color:var(--ink);border:1px solid var(--line);border-radius:6px;padding:5px 8px;background:#fff;width:100%}
   input:focus,select:focus,textarea:focus{outline:2px solid var(--cie-sec2);border-color:var(--cie-sec1)}
   textarea{resize:vertical;font-family:"Cascadia Code",Consolas,monospace;font-size:12.5px;line-height:1.4}
-  .wrap{display:grid;grid-template-columns:minmax(320px,420px) 1fr;gap:0;height:calc(100vh - 96px)}
+  .wrap{display:grid;grid-template-columns:minmax(380px,480px) 1fr;gap:0;height:calc(100vh - 96px)}
   .list-pane{border-right:1px solid var(--line);background:var(--panel);display:flex;flex-direction:column;min-height:0}
   .list-filters{padding:10px 12px;border-bottom:1px solid var(--line);display:flex;flex-direction:column;gap:8px}
   .list-filters .row{display:flex;gap:8px}
@@ -60,6 +60,7 @@
   a.doi-link:hover{color:var(--cie-main);border-bottom-style:solid}
   .chip{display:inline-block;font-size:10.5px;padding:1px 7px;border-radius:10px;background:var(--cie-sec3);color:#0a2a52;margin:1px 3px 1px 0}
   .chip.dom{background:#e3ecfb;border:1px solid var(--cie-sec2)}
+  .chip.rev{background:#eeece6;border:1px solid #d6d2c7;color:#6b665a}
   .badge{display:inline-block;font-size:10px;padding:1px 7px;border-radius:4px;font-weight:600;text-transform:uppercase;letter-spacing:.3px}
   .badge.draft{background:#fdf0d8;color:#8a5b00}
   .badge.review{background:#e0ecfb;color:#0a4aa0}
@@ -661,7 +662,13 @@ function newDB(){
     domains:clone(DEFAULT_DOMAINS), defaults:clone(DEFAULT_VALUES), entries:[]
   };
 }
-function computeDbBaseHash(db){ return sha256Str(db.entries.map(e=>e.contentHash).join("|")); }
+/* per-entry fingerprint for the DB hash: payload contentHash PLUS the envelope fields
+   (status/domains/landingPage) that are versioned outside the payload — so an envelope-only
+   edit still drifts the DB baseHash and marks the database unsaved. */
+function entryEnvFingerprint(e){
+  return e.contentHash+"~"+canonical({status:e.status||"", domains:(e.domains||[]).slice().sort(), landingPage:e.landingPage||""});
+}
+function computeDbBaseHash(db){ return sha256Str(db.entries.map(entryEnvFingerprint).join("|")); }
 function findEntry(id){ return DB.entries.find(e=>e.entryId===id); }
 
 function blankPayload(doi, filename){
@@ -1072,8 +1079,9 @@ function renderList(){
     const tr=document.createElement("tr");
     if(e.entryId===selectedId) tr.className="sel";
     const doms=(e.domains||[]).map(d=>`<span class="chip dom">${esc(d)}</span>`).join("");
+    const revChip=`<span class="chip rev" title="Metadata file revision">rev ${e.rev}</span>`;
     tr.innerHTML=`<td><div class="title-cell">${esc(entryTitle(e))}</div>
-        <div class="kv">${esc(entryFilename(e))}</div>${doms}</td>
+        <div class="kv">${esc(entryFilename(e))}</div>${doms}${revChip}</td>
       <td><div class="doi-cell">${esc(entryDoi(e))}</div>${dupIds.has(e.entryId)?'<span class="badge dup" title="Duplicate DOI — must be fixed">duplicate DOI</span>':''}</td>
       <td><span class="badge ${esc(e.status)}">${esc(e.status)}</span></td>
       <td class="kv">${esc((e.audit.modifiedDate||"").replace("T"," ").slice(0,19))}<br>${esc(e.audit.modifiedBy)}<br>rev ${e.rev}</td>`;

--- a/v4/tools/WebTool/CIEmetaDB.html
+++ b/v4/tools/WebTool/CIEmetaDB.html
@@ -2186,12 +2186,20 @@ async function saveDb(saveAs){
   markSaved(DB.baseHash); renderList();
   toast("Copy downloaded — this browser can't overwrite files or detect parallel edits. Use a Chromium browser for in-place save.","warn");
 }
+/* metadata-file name for an entry: <base>.csv_metadata[.vN].json, with the
+   revision suffix (_v2, _v3, …) appended only when the metadata revision > 1
+   (e.g. CIE_cc_1964_10deg.csv_metadata_v2.json), matching the published files. */
+function metadataFileName(e){
+  const base=entryFilename(e)||sanitize(entryTitle(e));
+  const stem=base.endsWith(".csv")?base+"_metadata":base+".csv_metadata";
+  const rev=(e.payload&&e.payload.metadataRevision)||e.rev||1;
+  return stem+(rev>1?"_v"+rev:"")+".json";
+}
 /* export entries as individual DataCite files (strip envelope) */
 function exportDataCiteFiles(entries){
   entries=entries||DB.entries;
   if(entries.length===1){
-    const e=entries[0]; const base=entryFilename(e)||sanitize(entryTitle(e));
-    const fn=base.endsWith(".csv")?base+"_metadata.json":base+".csv_metadata.json";
+    const e=entries[0]; const fn=metadataFileName(e);
     download(fn, JSON.stringify(e.payload,null,"\t"));
     toast("Exported "+fn,"ok"); return;
   }
@@ -2199,8 +2207,7 @@ function exportDataCiteFiles(entries){
   if(!confirm(`Export ${entries.length} metadata (DataCite) files as separate downloads?`)) return;
   let n=0;
   const step=()=>{ if(n>=entries.length){ toast("Exported "+entries.length+" files","ok"); return; }
-    const e=entries[n++]; const base=entryFilename(e)||sanitize(entryTitle(e));
-    const fn=base.endsWith(".csv")?base+"_metadata.json":base+".csv_metadata.json";
+    const e=entries[n++]; const fn=metadataFileName(e);
     download(fn, JSON.stringify(e.payload,null,"\t")); setTimeout(step,250); };
   step();
 }

--- a/v4/tools/WebTool/CIEmetaDBdataset.json
+++ b/v4/tools/WebTool/CIEmetaDBdataset.json
@@ -61,7 +61,7 @@
   "entries": [
     {
       "entryId": "dd141f8a-31b5-41cc-bf57-7eef4504829a",
-      "rev": 1,
+      "rev": 2,
       "contentHash": "64f60c28a898c7f96e03ed3329de496dfb0171a0f3b6856e7a77ff80aaf96648",
       "status": "published",
       "domains": [
@@ -69,10 +69,10 @@
       ],
       "audit": {
         "createdBy": "Peter Blattner",
-        "createdDate": "2026-07-21T15:36:06.376Z",
+        "createdDate": "2024-09-20T08:00:00.000Z",
         "modifiedBy": "Peter Blattner",
-        "modifiedDate": "2026-07-21T15:36:06.376Z",
-        "modifiedComment": "Imported from DataCite file"
+        "modifiedDate": "2024-09-20T16:00:00.000Z",
+        "modifiedComment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)"
       },
       "payload": {
         "identifier": {
@@ -204,13 +204,13 @@
         "schemaName": "CIEmetaDigitalProduct",
         "schemaVersion": 4,
         "schemaURL": "https://doi.org/10.25039/CIE.SC.4taqevcd",
-        "metadataRevision": 1
+        "metadataRevision": 2
       },
       "history": [
         {
           "rev": 1,
           "by": "Peter Blattner",
-          "date": "2026-07-21T15:36:06.376Z",
+          "date": "2024-09-20T08:00:00.000Z",
           "comment": "Imported from DataCite file",
           "baseHash": null,
           "patch": [
@@ -345,7 +345,7 @@
                 },
                 {
                   "hashMethod": "sha256",
-                  "checksum": "1f1413de6d58e533e8a3d26e4b7dc30f4cd6f67aebb7593fa3553394da939952"
+                  "checksum": "1f1413de6d58e533e8a3d26e4b7dc3f4cd6f67aebb7593fa3553394da939952"
                 }
               ]
             },
@@ -416,6 +416,29 @@
               "value": "https://doi.org/10.25039/CIE.SC.4taqevcd"
             }
           ]
+        },
+        {
+          "rev": 2,
+          "by": "Peter Blattner",
+          "date": "2024-09-20T16:00:00.000Z",
+          "comment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)",
+          "baseHash": "d72f9f6338d60338ade0b9d22d3db2020737cb6707901c48cd0c70c491eb8e6b",
+          "patch": [
+            {
+              "op": "replace",
+              "path": "/checksums",
+              "value": [
+                {
+                  "hashMethod": "md5",
+                  "checksum": "73de03dc084a116e3b79902d6d4e2c5a"
+                },
+                {
+                  "hashMethod": "sha256",
+                  "checksum": "1f1413de6d58e533e8a3d26e4b7dc30f4cd6f67aebb7593fa3553394da939952"
+                }
+              ]
+            }
+          ]
         }
       ],
       "validationLog": [
@@ -469,7 +492,7 @@
     },
     {
       "entryId": "ef380a5a-482c-4318-84c9-902095e2d306",
-      "rev": 1,
+      "rev": 2,
       "contentHash": "4b23944ef15ed70d5edd03bbc9d3ab825474b7728fd5b41fe88d4a706c4166ea",
       "status": "published",
       "domains": [
@@ -477,10 +500,10 @@
       ],
       "audit": {
         "createdBy": "Peter Blattner",
-        "createdDate": "2026-07-21T15:36:06.376Z",
+        "createdDate": "2024-09-20T08:00:00.000Z",
         "modifiedBy": "Peter Blattner",
-        "modifiedDate": "2026-07-21T15:36:06.376Z",
-        "modifiedComment": "Imported from DataCite file"
+        "modifiedDate": "2024-09-20T16:00:00.000Z",
+        "modifiedComment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)"
       },
       "payload": {
         "identifier": {
@@ -586,13 +609,13 @@
         "schemaName": "CIEmetaDigitalProduct",
         "schemaVersion": 4,
         "schemaURL": "https://doi.org/10.25039/CIE.SC.4taqevcd",
-        "metadataRevision": 1
+        "metadataRevision": 2
       },
       "history": [
         {
           "rev": 1,
           "by": "Peter Blattner",
-          "date": "2026-07-21T15:36:06.376Z",
+          "date": "2024-09-20T08:00:00.000Z",
           "comment": "Imported from DataCite file",
           "baseHash": null,
           "patch": [
@@ -714,7 +737,7 @@
                 },
                 {
                   "hashMethod": "sha256",
-                  "checksum": "23e07c6b8a2f5273f9e3abb3c64a374f3456eee0a70dd447fdb14c617f55224e"
+                  "checksum": "23e07c6b8a2f5273f9e3abb3c64a374f3456eee0a7dd447fdb14c617f55224e"
                 }
               ]
             },
@@ -770,6 +793,29 @@
               "op": "add",
               "path": "/schemaURL",
               "value": "https://doi.org/10.25039/CIE.SC.4taqevcd"
+            }
+          ]
+        },
+        {
+          "rev": 2,
+          "by": "Peter Blattner",
+          "date": "2024-09-20T16:00:00.000Z",
+          "comment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)",
+          "baseHash": "93afeac26b6c667a12bdd2a25f48c3fb200fa866d961227b8c6430b8f3960c6f",
+          "patch": [
+            {
+              "op": "replace",
+              "path": "/checksums",
+              "value": [
+                {
+                  "hashMethod": "md5",
+                  "checksum": "01dba8b4ebdbd2a3ebb9fa6cc8719939"
+                },
+                {
+                  "hashMethod": "sha256",
+                  "checksum": "23e07c6b8a2f5273f9e3abb3c64a374f3456eee0a70dd447fdb14c617f55224e"
+                }
+              ]
             }
           ]
         }
@@ -3827,7 +3873,7 @@
     },
     {
       "entryId": "9afa2e4c-4812-45e2-b546-2b7d6ca39496",
-      "rev": 1,
+      "rev": 2,
       "contentHash": "4ceeba8498cefcbe1a369b09ba139c2e4e226238281e24f37bb3b705a59b1809",
       "status": "published",
       "domains": [
@@ -3835,10 +3881,10 @@
       ],
       "audit": {
         "createdBy": "Peter Blattner",
-        "createdDate": "2026-07-21T15:36:06.376Z",
+        "createdDate": "2024-09-20T08:00:00.000Z",
         "modifiedBy": "Peter Blattner",
-        "modifiedDate": "2026-07-21T15:36:06.376Z",
-        "modifiedComment": "Imported from DataCite file"
+        "modifiedDate": "2024-09-20T16:00:00.000Z",
+        "modifiedComment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)"
       },
       "payload": {
         "identifier": {
@@ -3957,13 +4003,13 @@
         "schemaName": "CIEmetaDigitalProduct",
         "schemaVersion": 4,
         "schemaURL": "https://doi.org/10.25039/CIE.SC.4taqevcd",
-        "metadataRevision": 1
+        "metadataRevision": 2
       },
       "history": [
         {
           "rev": 1,
           "by": "Peter Blattner",
-          "date": "2026-07-21T15:36:06.376Z",
+          "date": "2024-09-20T08:00:00.000Z",
           "comment": "Imported from DataCite file",
           "baseHash": null,
           "patch": [
@@ -4098,7 +4144,7 @@
                 },
                 {
                   "hashMethod": "sha256",
-                  "checksum": "51c53bf065345fc1fb9d50aff40fb0a2ce370bcf35121a3dc4bafc0888602f0b"
+                  "checksum": "51c53bf065345fc1fb9d50aff4fb0a2ce37bcf35121a3dc4bafc0888602fb"
                 }
               ]
             },
@@ -4154,6 +4200,29 @@
               "op": "add",
               "path": "/schemaURL",
               "value": "https://doi.org/10.25039/CIE.SC.4taqevcd"
+            }
+          ]
+        },
+        {
+          "rev": 2,
+          "by": "Peter Blattner",
+          "date": "2024-09-20T16:00:00.000Z",
+          "comment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)",
+          "baseHash": "b8fb69af097128895b569365c61dfbcf99e33d8d77d3cdb420abb8458f042299",
+          "patch": [
+            {
+              "op": "replace",
+              "path": "/checksums",
+              "value": [
+                {
+                  "hashMethod": "md5",
+                  "checksum": "bb325f040bab332d91f8d9447aa47b78"
+                },
+                {
+                  "hashMethod": "sha256",
+                  "checksum": "51c53bf065345fc1fb9d50aff40fb0a2ce370bcf35121a3dc4bafc0888602f0b"
+                }
+              ]
             }
           ]
         }
@@ -4591,7 +4660,7 @@
     },
     {
       "entryId": "0f13447e-9229-4279-be5b-539910ef4bb7",
-      "rev": 1,
+      "rev": 2,
       "contentHash": "82054e066dba97502491eb130275ef2b8e6fc2f684fa6736e785328aa3450a86",
       "status": "published",
       "domains": [
@@ -4599,10 +4668,10 @@
       ],
       "audit": {
         "createdBy": "Peter Blattner",
-        "createdDate": "2026-07-21T15:36:06.376Z",
+        "createdDate": "2024-09-20T08:00:00.000Z",
         "modifiedBy": "Peter Blattner",
-        "modifiedDate": "2026-07-21T15:36:06.376Z",
-        "modifiedComment": "Imported from DataCite file"
+        "modifiedDate": "2024-09-20T16:00:00.000Z",
+        "modifiedComment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)"
       },
       "payload": {
         "identifier": {
@@ -4721,13 +4790,13 @@
         "schemaName": "CIEmetaDigitalProduct",
         "schemaVersion": 4,
         "schemaURL": "https://doi.org/10.25039/CIE.SC.4taqevcd",
-        "metadataRevision": 1
+        "metadataRevision": 2
       },
       "history": [
         {
           "rev": 1,
           "by": "Peter Blattner",
-          "date": "2026-07-21T15:36:06.376Z",
+          "date": "2024-09-20T08:00:00.000Z",
           "comment": "Imported from DataCite file",
           "baseHash": null,
           "patch": [
@@ -4862,7 +4931,7 @@
                 },
                 {
                   "hashMethod": "sha256",
-                  "checksum": "573a08831f2bcdf18a8e333490049e6d0fabaf1d1c0abbc2a49d6247a939b62d"
+                  "checksum": "573a08831f2bcdf18a8e333490049e6dfabaf1d1cabbc2a49d6247a939b62d"
                 }
               ]
             },
@@ -4918,6 +4987,29 @@
               "op": "add",
               "path": "/schemaURL",
               "value": "https://doi.org/10.25039/CIE.SC.4taqevcd"
+            }
+          ]
+        },
+        {
+          "rev": 2,
+          "by": "Peter Blattner",
+          "date": "2024-09-20T16:00:00.000Z",
+          "comment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)",
+          "baseHash": "bcbc3d48d222b934c8dcddb2c00989055a9699499774ad18f4fbabf8dfc9d993",
+          "patch": [
+            {
+              "op": "replace",
+              "path": "/checksums",
+              "value": [
+                {
+                  "hashMethod": "md5",
+                  "checksum": "fc2ae36ece39ad1729696ab2833bd013"
+                },
+                {
+                  "hashMethod": "sha256",
+                  "checksum": "573a08831f2bcdf18a8e333490049e6d0fabaf1d1c0abbc2a49d6247a939b62d"
+                }
+              ]
             }
           ]
         }
@@ -7173,7 +7265,7 @@
     },
     {
       "entryId": "7a4b58c2-3d2e-42f3-9203-c386f9be89cd",
-      "rev": 1,
+      "rev": 2,
       "contentHash": "1d42824a52a03a79651ead80c47ec270b7de160a12d477898d5b23d59b70c2b5",
       "status": "published",
       "domains": [
@@ -7181,10 +7273,10 @@
       ],
       "audit": {
         "createdBy": "Peter Blattner",
-        "createdDate": "2026-07-21T15:36:06.376Z",
+        "createdDate": "2024-09-20T08:00:00.000Z",
         "modifiedBy": "Peter Blattner",
-        "modifiedDate": "2026-07-21T15:36:06.376Z",
-        "modifiedComment": "Imported from DataCite file"
+        "modifiedDate": "2024-09-20T16:00:00.000Z",
+        "modifiedComment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)"
       },
       "payload": {
         "identifier": {
@@ -7340,13 +7432,13 @@
         "schemaName": "CIEmetaDigitalProduct",
         "schemaVersion": 4,
         "schemaURL": "https://doi.org/10.25039/CIE.SC.4taqevcd",
-        "metadataRevision": 1
+        "metadataRevision": 2
       },
       "history": [
         {
           "rev": 1,
           "by": "Peter Blattner",
-          "date": "2026-07-21T15:36:06.376Z",
+          "date": "2024-09-20T08:00:00.000Z",
           "comment": "Imported from DataCite file",
           "baseHash": null,
           "patch": [
@@ -7481,7 +7573,7 @@
                 },
                 {
                   "hashMethod": "sha256",
-                  "checksum": "035e09d62b27f4b1e362ff1ba99a50235f0d7886c2781c50d49851b6e4bb4552"
+                  "checksum": "035e09d62b27f4b1e362ff1ba99a50235fd7886c2781c50d49851b6e4bb4552"
                 }
               ]
             },
@@ -7574,6 +7666,29 @@
               "op": "add",
               "path": "/schemaURL",
               "value": "https://doi.org/10.25039/CIE.SC.4taqevcd"
+            }
+          ]
+        },
+        {
+          "rev": 2,
+          "by": "Peter Blattner",
+          "date": "2024-09-20T16:00:00.000Z",
+          "comment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)",
+          "baseHash": "32835d8c2ad0f2b7c241643e3fbe439d17de429222181b85b0ed9e4f8795e025",
+          "patch": [
+            {
+              "op": "replace",
+              "path": "/checksums",
+              "value": [
+                {
+                  "hashMethod": "md5",
+                  "checksum": "423e996fd3ee17eaf783633e4fd2f62c"
+                },
+                {
+                  "hashMethod": "sha256",
+                  "checksum": "035e09d62b27f4b1e362ff1ba99a50235f0d7886c2781c50d49851b6e4bb4552"
+                }
+              ]
             }
           ]
         }
@@ -7999,7 +8114,7 @@
     },
     {
       "entryId": "6c7d55ee-5743-4b92-9a21-4f7c034f6f85",
-      "rev": 1,
+      "rev": 2,
       "contentHash": "0e89da8d2be4abfc42e91b2705dffcda7a6eda36f29b09878f1b1d84542e634b",
       "status": "published",
       "domains": [
@@ -8007,10 +8122,10 @@
       ],
       "audit": {
         "createdBy": "Peter Blattner",
-        "createdDate": "2026-07-21T15:36:06.376Z",
+        "createdDate": "2024-09-20T08:00:00.000Z",
         "modifiedBy": "Peter Blattner",
-        "modifiedDate": "2026-07-21T15:36:06.376Z",
-        "modifiedComment": "Imported from DataCite file"
+        "modifiedDate": "2024-09-20T16:00:00.000Z",
+        "modifiedComment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)"
       },
       "payload": {
         "identifier": {
@@ -8123,13 +8238,13 @@
         "schemaName": "CIEmetaDigitalProduct",
         "schemaVersion": 4,
         "schemaURL": "https://doi.org/10.25039/CIE.SC.4taqevcd",
-        "metadataRevision": 1
+        "metadataRevision": 2
       },
       "history": [
         {
           "rev": 1,
           "by": "Peter Blattner",
-          "date": "2026-07-21T15:36:06.376Z",
+          "date": "2024-09-20T08:00:00.000Z",
           "comment": "Imported from DataCite file",
           "baseHash": null,
           "patch": [
@@ -8258,7 +8373,7 @@
                 },
                 {
                   "hashMethod": "sha256",
-                  "checksum": "be1dc615b4b03e0b4b3e294660101526a30ed17dc800e85786c29759b3dcb7a6"
+                  "checksum": "be1dc615b4b03eb4b3e294660101526a3ed17dc800e85786c29759b3dcb7a6"
                 }
               ]
             },
@@ -8316,6 +8431,29 @@
               "value": "https://doi.org/10.25039/CIE.SC.4taqevcd"
             }
           ]
+        },
+        {
+          "rev": 2,
+          "by": "Peter Blattner",
+          "date": "2024-09-20T16:00:00.000Z",
+          "comment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)",
+          "baseHash": "d127bf8c065fac792f6abf526b7f6ba639e251ae9712b5a881d1235959f4312a",
+          "patch": [
+            {
+              "op": "replace",
+              "path": "/checksums",
+              "value": [
+                {
+                  "hashMethod": "md5",
+                  "checksum": "c8843fdca93e747c8a3590cd74b01cfd"
+                },
+                {
+                  "hashMethod": "sha256",
+                  "checksum": "be1dc615b4b03e0b4b3e294660101526a30ed17dc800e85786c29759b3dcb7a6"
+                }
+              ]
+            }
+          ]
         }
       ],
       "validationLog": [
@@ -8369,7 +8507,7 @@
     },
     {
       "entryId": "f82d0656-040a-4318-b4e8-4101c9461ff7",
-      "rev": 1,
+      "rev": 2,
       "contentHash": "0f4bdf1905b537b340790b909563044621f83eedf1150f9f2183912f8814a058",
       "status": "published",
       "domains": [
@@ -8377,10 +8515,10 @@
       ],
       "audit": {
         "createdBy": "Peter Blattner",
-        "createdDate": "2026-07-21T15:36:06.376Z",
+        "createdDate": "2024-09-20T08:00:00.000Z",
         "modifiedBy": "Peter Blattner",
-        "modifiedDate": "2026-07-21T15:36:06.376Z",
-        "modifiedComment": "Imported from DataCite file"
+        "modifiedDate": "2024-09-20T16:00:00.000Z",
+        "modifiedComment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)"
       },
       "payload": {
         "identifier": {
@@ -8572,13 +8710,13 @@
         "schemaName": "CIEmetaDigitalProduct",
         "schemaVersion": 4,
         "schemaURL": "https://doi.org/10.25039/CIE.SC.4taqevcd",
-        "metadataRevision": 1
+        "metadataRevision": 2
       },
       "history": [
         {
           "rev": 1,
           "by": "Peter Blattner",
-          "date": "2026-07-21T15:36:06.376Z",
+          "date": "2024-09-20T08:00:00.000Z",
           "comment": "Imported from DataCite file",
           "baseHash": null,
           "patch": [
@@ -8713,7 +8851,7 @@
                 },
                 {
                   "hashMethod": "sha256",
-                  "checksum": "6147313bd1ec570ef308df222e1fe1e58115fde1ad0a7d4ba91fb9dcb776b267"
+                  "checksum": "6147313bd1ec57ef308df222e1fe1e58115fde1ada7d4ba91fb9dcb776b267"
                 }
               ]
             },
@@ -8842,6 +8980,29 @@
               "op": "add",
               "path": "/schemaURL",
               "value": "https://doi.org/10.25039/CIE.SC.4taqevcd"
+            }
+          ]
+        },
+        {
+          "rev": 2,
+          "by": "Peter Blattner",
+          "date": "2024-09-20T16:00:00.000Z",
+          "comment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)",
+          "baseHash": "dd328822cf099402051502b17d8185cdb3e11a4844e28fbe730198485233378b",
+          "patch": [
+            {
+              "op": "replace",
+              "path": "/checksums",
+              "value": [
+                {
+                  "hashMethod": "md5",
+                  "checksum": "91a73557fe319a085dd598ce96fa8ace"
+                },
+                {
+                  "hashMethod": "sha256",
+                  "checksum": "6147313bd1ec570ef308df222e1fe1e58115fde1ad0a7d4ba91fb9dcb776b267"
+                }
+              ]
             }
           ]
         }
@@ -14454,7 +14615,7 @@
     },
     {
       "entryId": "6043d076-fd73-4f53-b68a-5817feb6fdd9",
-      "rev": 1,
+      "rev": 2,
       "contentHash": "2c6c2f89fdafa53e8c89fdba452c67f256baba36369204b689683b958116acfa",
       "status": "published",
       "domains": [
@@ -14462,10 +14623,10 @@
       ],
       "audit": {
         "createdBy": "Peter Blattner",
-        "createdDate": "2026-07-21T15:36:06.376Z",
+        "createdDate": "2024-09-20T08:00:00.000Z",
         "modifiedBy": "Peter Blattner",
-        "modifiedDate": "2026-07-21T15:36:06.376Z",
-        "modifiedComment": "Imported from DataCite file"
+        "modifiedDate": "2024-09-20T16:00:00.000Z",
+        "modifiedComment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)"
       },
       "payload": {
         "identifier": {
@@ -15480,13 +15641,13 @@
         "schemaName": "CIEmetaDigitalProduct",
         "schemaVersion": 4,
         "schemaURL": "https://doi.org/10.25039/CIE.SC.4taqevcd",
-        "metadataRevision": 1
+        "metadataRevision": 2
       },
       "history": [
         {
           "rev": 1,
           "by": "Peter Blattner",
-          "date": "2026-07-21T15:36:06.376Z",
+          "date": "2024-09-20T08:00:00.000Z",
           "comment": "Imported from DataCite file",
           "baseHash": null,
           "patch": [
@@ -15630,7 +15791,7 @@
                 },
                 {
                   "hashMethod": "sha256",
-                  "checksum": "eb1d04a0d489918970f32354c2261581e9f9ba59456e0feae7227c7b5413aa3b"
+                  "checksum": "eb1d04a0d489918970f32354c2261581e9f9ba59456efeae7227c7b5413aa3b"
                 }
               ]
             },
@@ -16575,6 +16736,29 @@
               "value": "https://doi.org/10.25039/CIE.SC.4taqevcd"
             }
           ]
+        },
+        {
+          "rev": 2,
+          "by": "Peter Blattner",
+          "date": "2024-09-20T16:00:00.000Z",
+          "comment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)",
+          "baseHash": "d5332702f2b00ecc651dc54802a26b09562eb2d9324198f20890572ab735974f",
+          "patch": [
+            {
+              "op": "replace",
+              "path": "/checksums",
+              "value": [
+                {
+                  "hashMethod": "md5",
+                  "checksum": "11ef0bcbfaea43f1143ac40fbf52d7ff"
+                },
+                {
+                  "hashMethod": "sha256",
+                  "checksum": "eb1d04a0d489918970f32354c2261581e9f9ba59456e0feae7227c7b5413aa3b"
+                }
+              ]
+            }
+          ]
         }
       ],
       "validationLog": [
@@ -16633,7 +16817,7 @@
     },
     {
       "entryId": "a2446659-e673-4417-b297-36fbe32cf044",
-      "rev": 1,
+      "rev": 2,
       "contentHash": "ecbe48fcea173fa74770dd697c5fc9d627ed756698c4e40299643fd91c9958c8",
       "status": "published",
       "domains": [
@@ -16641,10 +16825,10 @@
       ],
       "audit": {
         "createdBy": "Peter Blattner",
-        "createdDate": "2026-07-21T15:36:06.376Z",
+        "createdDate": "2024-09-20T08:00:00.000Z",
         "modifiedBy": "Peter Blattner",
-        "modifiedDate": "2026-07-21T15:36:06.376Z",
-        "modifiedComment": "Imported from DataCite file"
+        "modifiedDate": "2024-09-20T16:00:00.000Z",
+        "modifiedComment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)"
       },
       "payload": {
         "identifier": {
@@ -17659,13 +17843,13 @@
         "schemaName": "CIEmetaDigitalProduct",
         "schemaVersion": 4,
         "schemaURL": "https://doi.org/10.25039/CIE.SC.4taqevcd",
-        "metadataRevision": 1
+        "metadataRevision": 2
       },
       "history": [
         {
           "rev": 1,
           "by": "Peter Blattner",
-          "date": "2026-07-21T15:36:06.376Z",
+          "date": "2024-09-20T08:00:00.000Z",
           "comment": "Imported from DataCite file",
           "baseHash": null,
           "patch": [
@@ -17809,7 +17993,7 @@
                 },
                 {
                   "hashMethod": "sha256",
-                  "checksum": "32327de84b4bb8715a2b2f1bce3f5d2eca6276a44bde19c93c6f0aad5742db63"
+                  "checksum": "32327de84b4bb8715a2b2f1bce3f5d2eca6276a44bde19c93c6faad5742db63"
                 }
               ]
             },
@@ -18754,6 +18938,29 @@
               "value": "https://doi.org/10.25039/CIE.SC.4taqevcd"
             }
           ]
+        },
+        {
+          "rev": 2,
+          "by": "Peter Blattner",
+          "date": "2024-09-20T16:00:00.000Z",
+          "comment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)",
+          "baseHash": "a29891b2cba0937f30defcc88eb24812d4e0e2bb6741cfd441558b6beef36504",
+          "patch": [
+            {
+              "op": "replace",
+              "path": "/checksums",
+              "value": [
+                {
+                  "hashMethod": "md5",
+                  "checksum": "5f8f0b2e6a30a8630bda424b85a1806d"
+                },
+                {
+                  "hashMethod": "sha256",
+                  "checksum": "32327de84b4bb8715a2b2f1bce3f5d2eca6276a44bde19c93c6f0aad5742db63"
+                }
+              ]
+            }
+          ]
         }
       ],
       "validationLog": [
@@ -18812,7 +19019,7 @@
     },
     {
       "entryId": "020236b1-90d5-4100-baaa-723f3e986df4",
-      "rev": 1,
+      "rev": 2,
       "contentHash": "f6c1b6787b84808d0406dd68a5bc7f7d970c797da2a54bc2bac89e9e7566ac28",
       "status": "published",
       "domains": [
@@ -18820,10 +19027,10 @@
       ],
       "audit": {
         "createdBy": "Peter Blattner",
-        "createdDate": "2026-07-21T15:36:06.376Z",
+        "createdDate": "2024-09-20T08:00:00.000Z",
         "modifiedBy": "Peter Blattner",
-        "modifiedDate": "2026-07-21T15:36:06.376Z",
-        "modifiedComment": "Imported from DataCite file"
+        "modifiedDate": "2024-09-20T16:00:00.000Z",
+        "modifiedComment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)"
       },
       "payload": {
         "identifier": {
@@ -19061,13 +19268,13 @@
         "schemaName": "CIEmetaDigitalProduct",
         "schemaVersion": 4,
         "schemaURL": "https://doi.org/10.25039/CIE.SC.4taqevcd",
-        "metadataRevision": 1
+        "metadataRevision": 2
       },
       "history": [
         {
           "rev": 1,
           "by": "Peter Blattner",
-          "date": "2026-07-21T15:36:06.376Z",
+          "date": "2024-09-20T08:00:00.000Z",
           "comment": "Imported from DataCite file",
           "baseHash": null,
           "patch": [
@@ -19199,7 +19406,7 @@
                 },
                 {
                   "hashMethod": "sha256",
-                  "checksum": "f461decedb5c18800c61a6923240c71f6cf91fd23ac94865133cbfdb7e05c0ad"
+                  "checksum": "f461decedb5c1880c61a6923240c71f6cf91fd23ac94865133cbfdb7e05c0ad"
                 }
               ]
             },
@@ -19377,6 +19584,29 @@
               "op": "add",
               "path": "/schemaURL",
               "value": "https://doi.org/10.25039/CIE.SC.4taqevcd"
+            }
+          ]
+        },
+        {
+          "rev": 2,
+          "by": "Peter Blattner",
+          "date": "2024-09-20T16:00:00.000Z",
+          "comment": "Correct SHA-256 checksum (fix leading-zero truncation in initial hash algorithm)",
+          "baseHash": "ad3abd39aff1a2ca3bf7d29dc2da21d87fc150494fc433da5670033233127325",
+          "patch": [
+            {
+              "op": "replace",
+              "path": "/checksums",
+              "value": [
+                {
+                  "hashMethod": "md5",
+                  "checksum": "6ad6522831a844edb8484e884d05c9e9"
+                },
+                {
+                  "hashMethod": "sha256",
+                  "checksum": "f461decedb5c18800c61a6923240c71f6cf91fd23ac94865133cbfdb7e05c0ad"
+                }
+              ]
             }
           ]
         }

--- a/v4/tools/WebTool/README.md
+++ b/v4/tools/WebTool/README.md
@@ -7,7 +7,7 @@ metadata records, with full git-like change history and safe concurrent-edit mer
 Modelled on the termdat curation workflow. Runs entirely in the browser from a
 local file — **no server, no network access, no external/CDN dependencies.**
 
-**Interface version 1.6.0** (shown in the header).
+**Interface version 1.7.0** (shown in the header).
 
 A **? Help** button in the toolbar opens an in-app summary of the features below,
 including the link to the Crossref deposit validator.
@@ -259,6 +259,29 @@ You can then:
   md5, sha256, overall pass/fail and every per-check result) into the entry's
   append-only `validationLog`, stored in the database. Past logged validations are
   listed under **Logged validations** in the same tab.
+
+## Compare an entry with an external metadata file
+
+Open an entry → **Compare with file…** (action bar, next to *Revert to defaults*) →
+pick a `*.csv_metadata.json` file. The tool compares that file against the entry's
+**stored** payload and lists the differences. It is **read-only** — nothing is
+imported, applied or changed.
+
+- **All fields are compared**, and arrays are compared **element by element**, so a
+  single changed value is pinpointed to its exact path (e.g.
+  `/checksums/1/checksum`) instead of showing a whole array as changed.
+- Differences use the same colours as the History diff: **~ changed**
+  (database → file), **+ only in file**, **− only in database**. A green banner
+  confirms when the file matches the entry exactly.
+- If the file's **DOI** or **file name** differs from the entry, a warning banner is
+  shown but the comparison still runs (so you can compare deliberately). The file is
+  also validated against the schema and any issues are noted. Both payloads are shown
+  raw, side by side, for context.
+- The bookkeeping `metadataRevision` field is **excluded** from the field comparison
+  (exported files do not carry it) but stays visible in the raw side-by-side view.
+
+Use it, for example, to confirm an exported file matches the database, or to see
+exactly what changed between a stored entry and an older published file.
 
 ## Concurrency — optimistic per-entry merge
 


### PR DESCRIPTION
## Summary
  Adds a revision suffix to metadata file names and several WebTool
  refinements around history, comparison, and the entry list.

  ## Changes
  - **Revision suffix in metadata file name** (`0b2ee8e`) — the metadata
    file name now carries its revision.
  - **Compare-with-file diff view** (`7f7262d`) — compare the current entry
    against a metadata file and see a field-level diff.
  - **v1→v2 checksum-fix history** (`48a3a6b`) — record the checksum fix as
    a history entry so the change is auditable.
  - **List & unsaved-state refinements** (`4a22830`):
    - Wider entry-list column on the left pane.
    - A muted "rev N" chip per entry in the list.
    - Envelope fields (status / domains / DOI landing page) now fold into
      the database base hash, so envelope-only saves correctly mark the
      database **unsaved** and trigger the close/reload and open-another
      warnings — while leaving the entry revision untouched.

  ## Testing
  Manually tested in the browser: list widening, rev chip rendering, and
  the unsaved-flag behaviour on envelope-only edits (Status change marks
  the DB unsaved without bumping the revision).

  ## Notes
  Single-file tool (`v4/tools/WebTool/CIEmetaDB.html`); no build step.