### PR TITLE
fix(webtool): rename buttons + timestamp on draft metadata export

### DIFF
--- a/v4/tools/WebTool/CIEmetaDB.html
+++ b/v4/tools/WebTool/CIEmetaDB.html
@@ -2360,16 +2360,20 @@ async function saveDb(saveAs){
   markSaved(DB.baseHash); renderList();
   toast("Copy downloaded — this browser can't overwrite files or detect parallel edits. Use a Chromium browser for in-place save.","warn");
 }
-/* metadata-file name for an entry: <base>.csv_metadata[_vN][_draft].json. The revision suffix
-   (_v2, _v3, …) is appended only when the (pending) revision > 1 (e.g.
+/* metadata-file name for an entry: <base>.csv_metadata[_vN][_draft[_TIMESTAMP]].json. The revision
+   suffix (_v2, _v3, …) is appended only when the (pending) revision > 1 (e.g.
    CIE_cc_1964_10deg.csv_metadata_v2.json), matching the published files. A draft entry uses its
-   PENDING revision — the version it will become when published — and gets a trailing _draft
-   (e.g. …_v2_draft.json, or …_metadata_draft.json for a first, never-published draft). */
+   PENDING revision — the version it will become when published — and gets a trailing _draft with a
+   timestamp (e.g. …_v2_draft_20260725T143022.json, or …_metadata_draft_20260725T143022.json for a
+   first, never-published draft). */
 function metadataFileName(e){
   const base=entryFilename(e)||sanitize(entryTitle(e));
   const stem=base.endsWith(".csv")?base+"_metadata":base+".csv_metadata";
   const rev=pendingRev(e)||1;
-  return stem+(rev>1?"_v"+rev:"")+(e.status==="draft"?"_draft":"")+".json";
+  const draftSuffix=e.status==="draft"
+    ?"_draft_"+new Date().toISOString().replace(/-/g,"").replace(/:/g,"").slice(0,15)
+    :"";
+  return stem+(rev>1?"_v"+rev:"")+draftSuffix+".json";
 }
 /* export entries as individual DataCite files (strip envelope) */
 function exportDataCiteFiles(entries){
@@ -2671,8 +2675,8 @@ function openHelpDialog(){
         revision (RFC-6902 patch), bumps the revision number and sets status to <b>published</b>.
         History therefore shows revision-to-revision changes, never intermediate draft saves.</li>
       <li>The payload's <span class="mono">metadataRevision</span> mirrors the published revision and is
-        stamped automatically. Exporting a <b>draft</b> appends <span class="mono">_draft</span> after
-        the (pending) revision number in the file name (e.g. <span class="mono">…_metadata_v2_draft.json</span>).</li>
+        stamped automatically. Exporting a <b>draft</b> appends <span class="mono">_draft_TIMESTAMP</span> after
+        the (pending) revision number in the file name (e.g. <span class="mono">…_metadata_v2_draft_20260725T143022.json</span>).</li>
       <li><b>Undo changes</b> discards unsaved editor edits and returns to the last <i>saved</i> version.
         <b>Revert to last published</b> discards unpublished draft edits and restores the entry to its
         last published revision (immediate, with a confirmation — draft edits are not versioned and are lost).</li>

--- a/v4/tools/WebTool/CIEmetaDB.html
+++ b/v4/tools/WebTool/CIEmetaDB.html
@@ -260,7 +260,7 @@ const DEFAULT_VALUES = {
   interpolationMethod: ":unap",
   extrapolationMethod: ":unap",
   dataQuality: ":unap",
-  // Crossref deposit header / database-level metadata (used by "Export to Crossref-file (XML)")
+  // Crossref deposit header / database-level metadata (used by "Create Crossref-file (XML)")
   crDepositorName: "CIE",
   crDepositorEmail: "ciecb@cie.co.at",
   crRegistrant: "International Commission on Illumination (CIE)",
@@ -1153,11 +1153,11 @@ function renderDetail(){
       <button id="btnSaveEntry">Save draft</button>
       <button id="btnPublish" title="Create a new revision and mark the entry published">Publish entry</button>
       <button class="ghost" id="btnRevert" title="Discard unsaved editor changes and return to the last saved version">Undo changes</button>
-      <button class="ghost" id="btnRevertPublished" title="Discard unpublished draft edits and restore the last published revision">Revert to last published</button>
+      <button class="ghost" id="btnRevertPublished" title="Discard unpublished draft edits and restore the last published revision">Revert to <br>last published</button>
       <button class="ghost" id="btnCompareFile" title="Compare this entry with an exported *.csv_metadata.json file">Compare with<br>metadata-file (JSON)</button>
       <button class="ghost" id="btnValidateCsv" title="Validate this entry against its CSV data file">Validate against<br>data-file (CSV, &hellip;)</button>
-      <button class="ghost" id="btnExportOne" title="Export this entry as a *.csv_metadata.json file">Export to<br>metadata-file (JSON)</button>
-      <button class="ghost" id="btnExportCrossref" title="Export a Crossref 5.3.1 deposit file for this entry">Export to<br>Crossref-file (XML)</button>
+      <button class="ghost" id="btnExportOne" title="Export this entry as a *.csv_metadata.json file">Export<br>metadata-file (JSON)</button>
+      <button class="ghost" id="btnExportCrossref" title="Create a Crossref 5.3.1 deposit file for this entry">Create <br>Crossref-file (XML)</button>
       <button class="ghost" id="btnDupe">Duplicate</button>
       <button class="danger" id="btnDelete">Delete</button>
     </div>`;
@@ -2539,7 +2539,7 @@ function exportCrossrefXml(e){
   doCrossrefExport(e, lp);
 }
 function doCrossrefExport(e, landingPage){
-  if(!entryDoi(e)){ if(!confirm("This entry has no DOI. Export to Crossref-file (XML) anyway (with an empty <doi>)?")) return; }
+  if(!entryDoi(e)){ if(!confirm("This entry has no DOI. Create a Crossref-file (XML) anyway (with an empty <doi>)?")) return; }
   const {xml, batchId, skipped}=buildCrossrefXml(e, landingPage);
   download(batchId+".xml", xml, "application/xml");
   if(skipped.length) toast("Exported "+batchId+".xml — skipped unmapped relation(s): "+[...new Set(skipped)].join(", "),"err");
@@ -2727,8 +2727,8 @@ function openHelpDialog(){
       section of the Form tab. Crossref requires it for the <code>&lt;resource&gt;</code> element;
       if it is empty when you export, the tool prompts for it and saves it on the entry.</p>
 
-    <h4>Export to Crossref-file (XML) <span class="kv">(new)</span></h4>
-    <p style="margin:4px 0">The per-entry <b>Export to Crossref-file (XML)</b> button (entry action bar)
+    <h4>Create a Crossref-file (XML) <span class="kv">(new)</span></h4>
+    <p style="margin:4px 0">The per-entry <b>Create a Crossref-file (XML)</b> button (entry action bar)
       generates a Crossref 5.3.1 <code>&lt;doi_batch&gt;</code> deposit file for the selected entry,
       ready for DOI registration.</p>
     <ul>


### PR DESCRIPTION
  ## Changes

  - **Button renames** — action-bar and toolbar button labels updated for
    clarity (exact renames per commit 60283d3).
  - **Draft export filename timestamp** — when exporting a metadata-file
    (JSON) for an entry in draft status, the filename now includes an
    export timestamp:
    `…_metadata_draft_20260725T143022.json` / `…_metadata_v2_draft_20260725T143022.json`
    This makes successive draft exports distinguishable without
    overwriting each other. Published entries are unaffected.

  ## Test

  - Export a draft entry → confirm filename contains `_draft_<timestamp>`.
  - Export a published entry → confirm filename has no timestamp.
  - Help dialog → verify the example filename reflects the new format.