### PR TITLE
fix(schema): repair v4 schema file defectsFix/schema 04 defects

### DIFF
--- a/v4/docs/INTEROPERABILITY.md
+++ b/v4/docs/INTEROPERABILITY.md
@@ -24,7 +24,7 @@ The database is the authoritative corpus. Note that the `../examples/` folder is
 subset** — 36 records rather than 39 (`CIE_srf_CQS_5nm`, `CIE_srf_FCI_5nm` and
 `CIE_srf_PS_5nm` are missing) and several of its copies predate corrections that have since
 been made in the database. Analyses run against `../examples/` therefore overstate some
-defect counts; see section 10.2.
+defect counts; see section 10.
 
 ---
 
@@ -63,8 +63,7 @@ invalidating it, and every existing record remains valid unchanged. `schemaName`
 
 This was checked, not assumed: the published `CIE_cc_1931_2deg` payload with `unitPID`,
 `quantityPID` and `symbol` added to every column validates against
-`CIEmetaDigitalProduct_schema_04.json` under a draft-07 validator — once the `//` comments
-are removed so that the schema file can be parsed at all (defect 1, section 10.1).
+`CIEmetaDigitalProduct_schema_04.json` under a draft-07 validator.
 
 Section 10 lists defects that already exist in v4 and should be repaired regardless of
 whether any recommendation here is adopted.
@@ -89,9 +88,9 @@ Column semantics live at
             "unit":             { "type": "string" },
             "quantity":         { "type": "string" },
             "description":      { "type": "string" },
-            "wavelength_first": { "type": "number" },
-            "wavelength_last":  { "type": "number" },
-            "wavelength_step":  { "type": "number" }
+            "wavelength_first": { "$ref": "#/definitions/wavelengthField" },
+            "wavelength_last":  { "$ref": "#/definitions/wavelengthField" },
+            "wavelength_step":  { "$ref": "#/definitions/wavelengthField" }
         }
     },
     "uniqueItems": true
@@ -133,11 +132,11 @@ them; there are no empty, absent or sentinel unit values anywhere in the corpus:
 | `"action spectra"` | 5 |
 | `"spectral luminous efficiency"` | 4 |
 | `"luminous efficiency"` | 2 |
-| `"  "` (whitespace — defect 5) | 2 |
+| `"  "` (whitespace — defect 1) | 2 |
 | `"adaptation coefficient"` | 1 |
 | `"maximum luminous efficacy"` | 1 |
 
-A further 6 columns omit the `quantity` key entirely (defect 6). The unit column is
+A further 6 columns omit the `quantity` key entirely (defect 2). The unit column is
 therefore in better shape than the quantity column: `unit` is complete and consistent,
 `quantity` has 8 defective columns out of 402.
 
@@ -461,9 +460,9 @@ ROR identifier, verified:
 ```
 
 Where an individual is credited, `nameIdentifierScheme: "ORCID"` with the full
-`https://orcid.org/…` form. `funderIdentifierType` currently enumerates
-`["ISNI", "GRID", "Crossref Funder ID", "Other"]`; **ROR should be added** — GRID has been
-superseded by ROR since 2021.
+`https://orcid.org/…` form. `funderIdentifierType` previously enumerated
+`["ISNI", "GRID", "Crossref Funder ID", "Other"]`, offering the superseded GRID but not ROR;
+**`"ROR"` has since been added** to the schema — see the version history in [README.md](README.md).
 
 **Subjects.** `subjects[]` supports `subjectScheme`, `schemeURI`, `valueURI` and
 `classificationCode`. Across the 39 records there are **113 subject entries drawing on 14
@@ -482,7 +481,7 @@ anywhere:
 
 The list reads as entries from a classification rather than free keywords, and the
 right-hand column shows the cost of not saying so: three of the fourteen are
-capitalisation variants of another three (defect 9). Fourteen values is small enough to
+capitalisation variants of another three (defect 5). Fourteen values is small enough to
 enumerate. Declaring the scheme costs one field per subject and makes the values
 resolvable; if the strings are ad-hoc, CIE should adopt a scheme — the e-ILV itself would
 be a natural source once recommendation G is in place.
@@ -624,62 +623,55 @@ that the SI Reference Point has made BIPM the cited source for units.
 
 ## 10. Defect register
 
-Independent of the recommendations above. These are defects in v4 as published.
+Independent of the recommendations above. These are defects in the published data,
+measured against the 39 entries in `CIEmetaDBdataset.json`. The affected share of the corpus
+is small — 8 defective columns out of 402, plus the subject-casing issue.
 
-### 10.1 To fix in the schema file
-
-| # | Defect | Detail | Fix |
-|---|---|---|---|
-| 1 | **The schema file is not valid JSON** | Lines 2–34 of `CIEmetaDigitalProduct_schema_04.json` are `//` line comments inside the object. Any strict parser rejects the file. | Move the changelog into `$comment` strings or a sibling `.md`. |
-| 2 | **`wavelength_*` type contradicts the documentation and the data** | The schema declares `{"type": "number"}`. README.md CIE 2.4.5–2.4.7 requires `":unap"` / `":null"` for non-spectral tables, and `CIE_max_sle_mesopic` uses them. **The published schema currently rejects a published CIE record.** | `"anyOf": [{"type":"number"}, {"type":"string","enum":[":unap",":null",":unal",":unas"]}]` |
-| 3 | **No `$id`** | The schema cannot be referenced by URI from another schema or a validator. | Add `"$id"`, pointing at the schema DOI or a stable cie.co.at URL. |
-| 4 | **`funderIdentifierType` lacks ROR** | Enumerates the superseded GRID but not ROR. | Add `"ROR"`. |
-
-Defect 2 is masked in practice: the WebTool does not load the schema file at all. It
-re-implements it in JavaScript (`buildCieSchema()`, `CIEmetaDB.html` around line 579) and
-its private copy already permits the sentinels:
-
-```js
-// wavelength fields are numeric, but the CIE README allows sentinel strings for non-spectral tables
-const wlField = { anyOf:[ {type:"number"},
-                          {type:"string", enum:[":unap",":null",":unal",":unas"]} ] };
-```
-
-So the tool validates records that the published schema rejects. The two must be
-reconciled — and note that **any schema change has to be made in two places**, the JSON
-file and `CIEmetaDB.html` (`ENUMS` around line 276 and `buildCieSchema()`). That
-duplication is itself a maintenance risk worth addressing separately.
-
-Also note `:null` appears in the tool's enum and in README.md but is not part of the
-`:unap`/`:unas`/`:unal` sentinel family used elsewhere, and no data file uses it.
-
-### 10.2 To fix in the data
-
-Measured against the 39 published entries in `CIEmetaDBdataset.json`. The affected share of
-the corpus is small — 8 defective columns out of 402, plus the subject-casing issue.
+Defects in the *schema file* — it was not valid JSON, it had no `$id`, its `wavelength_*`
+fields rejected the sentinel strings the documentation requires, and `funderIdentifierType`
+lacked ROR — have been corrected. See the version history in
+[README.md](README.md) and the `$comment` in
+[`../schema/CIEmetaDigitalProduct_schema_04.json`](../schema/CIEmetaDigitalProduct_schema_04.json).
 
 | # | Defect | Extent | Datasets |
 |---|---|---|---|
-| 5 | `"quantity": "  "` (whitespace) on the `lambda` column | 2 columns | `CIE_illum_D55`, `CIE_illum_D75` |
-| 6 | `quantity` key absent | 6 columns | `CIE_1st_deriv_meta_ind` (`delta_x_bar(lambda)`, `delta_y_bar(lambda)`, `delta_z_bar(lambda)`), `CIE_illum_Dxx_comp` (`S_0(lambda)`, `S_1(lambda)`, `S_2(lambda)`) |
-| 7 | **`descrition` typo** instead of `description` | 15 columns in **1** dataset | `CIE_srf_CQS_5nm` |
-| 8 | `β15(λ)` — the only non-ASCII column title in the corpus, where every other dataset transliterates (`x_bar`, `lambda`) | 1 column | `CIE_srf_PS_5nm` |
-| 9 | **Subject casing is inconsistent** — the same concept appears under two spellings | 6 subject entries | `Perception of colour` (10) vs `Perception of Colour` (2); `Colour of objects` (10) vs `Colour of Objects` (2); `Colour vision` (10) vs `Colour Vision` (2) |
-| 10 | v3 example declares `"schemaName": "CIEmetaDataProduct"` (vs `CIEmetaDigitalProduct` in its own schema) and reuses the **v4** `schemaURL` DOI | 1 file | `v3/examples/CIE_cc_1931_2deg.csv_metadata.json` |
+| 1 | `"quantity": "  "` (whitespace) on the `lambda` column | 2 columns | `CIE_illum_D55`, `CIE_illum_D75` |
+| 2 | `quantity` key absent | 6 columns | `CIE_1st_deriv_meta_ind` (`delta_x_bar(lambda)`, `delta_y_bar(lambda)`, `delta_z_bar(lambda)`), `CIE_illum_Dxx_comp` (`S_0(lambda)`, `S_1(lambda)`, `S_2(lambda)`) |
+| 3 | **`descrition` typo** instead of `description` | 15 columns in **1** dataset | `CIE_srf_CQS_5nm` |
+| 4 | `β15(λ)` — the only non-ASCII column title in the corpus, where every other dataset transliterates (`x_bar`, `lambda`) | 1 column | `CIE_srf_PS_5nm` |
+| 5 | **Subject casing is inconsistent** — the same concept appears under two spellings | 6 subject entries | `Perception of colour` (10) vs `Perception of Colour` (2); `Colour of objects` (10) vs `Colour of Objects` (2); `Colour vision` (10) vs `Colour Vision` (2) |
+| 6 | v3 example declares `"schemaName": "CIEmetaDataProduct"` (vs `CIEmetaDigitalProduct` in its own schema) and reuses the **v4** `schemaURL` DOI | 1 file | `v3/examples/CIE_cc_1931_2deg.csv_metadata.json` |
 
-Defect 7 is the one that silently loses information: a consumer reading `description` gets
+Defect 3 is the one that silently loses information: a consumer reading `description` gets
 nothing for those 15 columns. Note that it is **far less widespread than the `../examples/`
 folder suggests** — the stale copies there carry the typo in 12 files, but in the live
 database only `CIE_srf_CQS_5nm` still has it. Most occurrences have already been corrected;
 this is the remainder.
 
-Defect 9 is a direct illustration of why recommendation F matters. Fourteen distinct subject
+Defect 5 is a direct illustration of why recommendation F matters. Fourteen distinct subject
 strings are in use across 113 subject entries, all as bare strings with no
 `subjectScheme`, `schemeURI` or `valueURI` — nothing prevents the same concept being
 entered twice with different capitalisation, and nothing detects it afterwards.
 
-Fixing any of 5–9 changes metadata content and therefore increments `metadataRevision`
+Fixing any of 1–5 changes metadata content and therefore increments `metadataRevision`
 per CIE 3.
+
+### 10.1 Maintenance note — the schema is defined twice
+
+Not a defect in the data, but the condition that let one of the schema-file defects go
+unnoticed, and it still holds. The WebTool never loads
+`CIEmetaDigitalProduct_schema_04.json`; it re-implements it in JavaScript (`ENUMS` around
+line 276 and `buildCieSchema()` around line 580 of `CIEmetaDB.html`). **Any schema change
+therefore has to be made in two places.** When the two drifted, the tool went on accepting
+records that the published schema rejected, and nothing reported it.
+
+The tool cannot simply fetch the schema file: it is designed to run from `file://`, where
+`fetch` is blocked. Inlining the schema at build time, or a check that fails when the two
+definitions diverge, would remove the class of defect rather than one instance of it.
+
+A related loose end: `":null"` appears in both sentinel lists and in README.md, but it is
+not part of the `":unap"` / `":unas"` / `":unal"` family used elsewhere, and no data file
+uses it.
 
 ---
 
@@ -732,8 +724,8 @@ coordinate against wavelength?".
 
 ### 11.3 `CIE_max_sle_mesopic` — the hard case
 
-The only non-spectral table, the only real physical unit, and the source of the sentinel
-problem in defect 2.
+The only non-spectral table, the only real physical unit, and the record whose sentinel
+values the schema file used to reject.
 
 ```json
 "columnHeaders": [
@@ -766,16 +758,21 @@ concept with no identifier — better an honest gap than a fabricated URI.
 
 ## 12. Roadmap
 
-**Phase 1 — schema hygiene.** Defects 1–4 and 5–9. No new fields, no change to the model.
-Every existing record stays valid; records touched under 10.2 increment `metadataRevision`.
-Effort: small. This phase is worth doing on its own merits.
+**Phase 1 — schema hygiene.** No new fields, no change to the model.
+
+- *Schema file: **done.*** Valid JSON, `$id`, sentinel-tolerant `wavelength_*`, ROR.
+  `schemaVersion` stays `4`, the schema DOI is unchanged, and all 39 published records now
+  validate against the file. See the version history in [README.md](README.md).
+- *Data (section 10, defects 1–5): outstanding.* Records touched increment
+  `metadataRevision` per CIE 3. Effort: small — 8 defective columns out of 402, plus the
+  subject-casing variants.
 
 **Phase 2 — semantic annotation.** Add `unitPID`, `quantityPID`, `symbol` as optional
 fields; publish the appendix table as a normative annex to README.md; extend the WebTool so
 the Quantity and Unit inputs become dropdowns backed by that table, with the PID filled in
 automatically. Currently both are plain text inputs (`CIEmetaDB.html` around lines
 1443–1444) and the conventions are enforced by nothing — which is how the whitespace and
-missing-key defects arose. Remember the two-places rule for schema changes (10.1).
+missing-key defects arose. Remember the two-places rule for schema changes (section 10.1).
 `schemaVersion` stays `4`; document the change as 4.2. Effort: small for the data, moderate
 for the tool.
 

--- a/v4/docs/README.md
+++ b/v4/docs/README.md
@@ -365,6 +365,14 @@ Note the distinction from the DataCite `Version` field (property 15 above): `Ver
 
 ## Version history
 
+Version 4.1 - schema file corrections:
+
+Editorial corrections to `CIEmetaDigitalProduct_schema_04.json` only. The metadata model itself is unchanged: `schemaName`/`schemaVersion` stay `CIEmetaDigitalProduct`/`4`, the schema DOI is unchanged, and none of the corrections can invalidate an existing metadata file - each only widens what is accepted.
+- The schema file is now **valid JSON**. Its descriptive header was previously written as `//` line comments inside the root object, which made the file unparsable by a strict JSON parser - and therefore unusable with the online validators recommended at the top of this document. That text is now carried in the `title`, `description` and `$comment` keywords; no information was removed.
+- `$id` added (`https://doi.org/10.25039/CIE.SC.4taqevcd`, the same persistent identifier that every metadata file carries as `schemaURL`), so the schema can be referenced by URI.
+- `wavelength_first`, `wavelength_last` and `wavelength_step` now reference a new `definitions.wavelengthField`, which accepts **either** a number **or** one of the sentinel strings `":unap"`, `":null"`, `":unal"`, `":unas"`. They were previously declared as plain numbers, which contradicted CIE 2.4.5 - 2.4.7 above and rejected the published metadata of non-spectral data tables such as `CIE_max_sle_mesopic`.
+- `"ROR"` added to `funderIdentifierType` (property 19), which previously offered the superseded GRID but not ROR.
+
 Version 4.1:
 - Optional field `metadataRevision` added (see CIE 3 above). It is the revision of the JSON metadata file itself:
   - integer, starting at 1, incremented by 1 on every change of the metadata content (e.g. a corrected checksum, an added/edited column header, a fixed title or description);

--- a/v4/schema/CIEmetaDigitalProduct_schema_04.json
+++ b/v4/schema/CIEmetaDigitalProduct_schema_04.json
@@ -1,38 +1,9 @@
 {
-//
-//  CIEmetaDigitalProduct Schema
-//  ---------------------
-//
-// based on
-// https://github.com/datacite/schema/blob/76de5e551d19e3e9b829af2f38ccc13e8c7677fe/source/json/kernel-4.3/datacite_4.3_schema.json
-// to become datacite version 4.4:
-// -field classificationCode added in the subjects field
-// -address of metaschema has been changed
-// -additional resourceTypeGeneral items
-// -relatedItem added
-// -only one identifier is allowed (as in the official schema), additional are introduced by "alternateIdentifier"
-//  -schemaType replaced by schemaName
-//  -relatedItem.title replaced relatedItem.titles (array of string) to be compatible with strict datacite 4.4 xml definition
-//
-//  CIE additions:
-//  --------------
-//  checksums (recommended)
-//  datatableInfo (validation,dataQuality,extrapolationMethod, interpolationMethod)
-//  schemaName (required)
-//	schemaVersion (required)
-//	schemaURL:(required)
-//	metadataRevision (optional): revision of the JSON metadata file itself (not the resource; see DataCite "version"). Increments only on metadata-content changes.//
-//   
-//  to validate your JSON file use any online tool, i.e.: https://www.jsonschemavalidator.net/
-//
-//
-//  version history
-//
-//  4.0 : new fields added in the column headers: wavelength_from, wavelength_to, wavelength_step
-//  4.1 : optional field metadataRevision added (revision of the JSON metadata file; backward-compatible, schemaVersion stays 4)
-//
-//
-"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://doi.org/10.25039/CIE.SC.4taqevcd",
+	"title": "CIEmetaDigitalProduct",
+	"description": "Metadata schema for digital products published by the International Commission on Illumination (CIE), in particular data tables distributed as CSV alongside CIE publications. Based on the DataCite metadata kernel with CIE-specific additions. The accompanying description of the metadata model, including the obligation (mandatory / recommended / optional) of each property, is published at https://github.com/CIEmetaSchemas/CIEmetaDigitalProduct (v4/docs/README.md). To validate a metadata file against this schema, any JSON Schema draft-07 validator can be used, for example https://www.jsonschemavalidator.net/ .",
+	"$comment": "Based on the DataCite kernel-4.3 JSON schema:\nhttps://github.com/datacite/schema/blob/76de5e551d19e3e9b829af2f38ccc13e8c7677fe/source/json/kernel-4.3/datacite_4.3_schema.json\n\nChanges towards DataCite version 4.4:\n- field classificationCode added in the subjects field\n- address of metaschema has been changed\n- additional resourceTypeGeneral items\n- relatedItem added\n- only one identifier is allowed (as in the official schema), additional ones are introduced by \"alternateIdentifier\"\n- schemaType replaced by schemaName\n- relatedItem.title replaced by relatedItem.titles (array of string) to be compatible with the strict DataCite 4.4 XML definition\n\nCIE additions:\n- checksums (recommended)\n- datatableInfo (validation, dataQuality, extrapolationMethod, interpolationMethod)\n- schemaName (required)\n- schemaVersion (required)\n- schemaURL (required)\n- metadataRevision (optional): revision of the JSON metadata file itself (not the resource; see DataCite \"version\"). Increments only on metadata-content changes.\n\nVersion history:\n4.0 : new fields added in the column headers: wavelength_first, wavelength_last, wavelength_step\n4.1 : optional field metadataRevision added (revision of the JSON metadata file; backward-compatible, schemaVersion stays 4)\n4.1 : schema file corrections (editorial only; schemaVersion stays 4 and the schema DOI is unchanged). None of these can invalidate an existing metadata file - they only widen what is accepted:\n      - the file is now valid JSON. The descriptive header was previously written as // line comments inside the root object, which made the file unparsable by a strict JSON parser (and therefore unusable with the validators recommended above). That text is now carried in description and in this $comment.\n      - $id added.\n      - wavelength_first / wavelength_last / wavelength_step now reference definitions.wavelengthField, which accepts a number or one of the sentinel strings documented in v4/docs/README.md (CIE 2.4.5 - 2.4.7). Previously declared as plain numbers, which contradicted both the documentation and published metadata files for non-spectral data tables.\n      - \"ROR\" added to funderIdentifierType (GRID has been superseded by ROR).",
 	"definitions": {
 		"nameType": {
 			"type": "string",
@@ -341,7 +312,25 @@
 				"ISNI",
 				"GRID",
 				"Crossref Funder ID",
+				"ROR",
 				"Other"
+			]
+		},
+		"wavelengthField": {
+			"$comment": "A wavelength bound or step in nm. For non-spectral data tables, and for a wavelength_step that is not constant over the full range, the sentinel strings documented in v4/docs/README.md (CIE 2.4.5 - 2.4.7) are used instead of a number.",
+			"anyOf": [
+				{
+					"type": "number"
+				},
+				{
+					"type": "string",
+					"enum": [
+						":unap",
+						":null",
+						":unal",
+						":unas"
+					]
+				}
 			]
 		}
 	},
@@ -897,13 +886,13 @@
 								"type": "string"
 							},
 							"wavelength_first": {
-								"type": "number"
+								"$ref": "#/definitions/wavelengthField"
 							},
 							"wavelength_last": {
-								"type": "number"
+								"$ref": "#/definitions/wavelengthField"
 							},
 							"wavelength_step": {
-								"type": "number"
+								"$ref": "#/definitions/wavelengthField"
 							}
 						}
 					},

--- a/v4/tools/WebTool/CIEmetaDB.html
+++ b/v4/tools/WebTool/CIEmetaDB.html
@@ -581,7 +581,8 @@ const CIE_SCHEMA = buildCieSchema();
 function buildCieSchema(){
   const D=ENUMS;
   const strEnum=arr=>({type:"string",enum:arr});
-  // wavelength fields are numeric, but the CIE README allows sentinel strings for non-spectral tables
+  // mirrors definitions.wavelengthField in CIEmetaDigitalProduct_schema_04.json: a number,
+  // or one of the sentinel strings the CIE README allows for non-spectral tables
   const wlField={anyOf:[{type:"number"},{type:"string",enum:[":unap",":null",":unal",":unas"]}]};
   const nameIds={type:"array",items:{type:"object",properties:{nameIdentifier:{type:"string"},nameIdentifierScheme:{type:"string"},schemeURI:{type:"string"}},required:["nameIdentifier","nameIdentifierScheme"]}};
   const affils={type:"array",items:{type:"object",properties:{affiliation:{type:"string"}},required:["affiliation"]}};


### PR DESCRIPTION
 ## What

  Four editorial corrections to `v4/schema/CIEmetaDigitalProduct_schema_04.json`, fixing the schema-file defects the interoperability review identified.

  The metadata model is unchanged. `schemaName`/`schemaVersion` stay `CIEmetaDigitalProduct`/`4`, the schema DOI is unchanged, and **none of the corrections can invalidate an existing
  metadata file** — each only widens what is accepted.

  ## Why

  The substantive defect: `wavelength_first`, `wavelength_last` and `wavelength_step` were declared `{"type": "number"}`, but `v4/docs/README.md` (CIE 2.4.5–2.4.7) requires the sentinel
  strings `":unap"` / `":null"` for non-spectral tables, and the published dataset `CIE_max_sle_mesopic` uses them.

  **The published schema rejected a published CIE record** — 6 validation errors, one per sentinel-valued field.

  Compounding it, the schema file was not valid JSON: a block of `//` line comments sat inside the root object, so a strict parser rejected the file outright — including the online
  validators README.md itself recommends.

  ## The four fixes

  | # | Was | Now |
  |---|---|---|
  | 1 | Header written as `//` comments inside the root object → file unparsable | Text carried in `title`, `description` and a multi-line `$comment`. Nothing discarded — all 22 original  comment lines verified as represented. |
  | 2 | `wavelength_*` declared as plain numbers | New `definitions.wavelengthField`: `anyOf` a number or `":unap"` / `":null"` / `":unal"` / `":unas"`, `$ref`'d from all three fields |
  | 3 | No `$id` | `"$id": "https://doi.org/10.25039/CIE.SC.4taqevcd"` — the persistent identifier every record already carries as `schemaURL` |
  | 4 | `funderIdentifierType` offered the superseded GRID but not ROR | `["ISNI", "GRID", "Crossref Funder ID", "ROR", "Other"]` |

  Fix 2 uses a `definition` + `$ref` rather than repeating the union three times, matching how the file already handles `interpolationMethod` and `dataQuality`.

  ## The WebTool needed no functional change

  Worth being explicit about, since it looks like an omission. `buildCieSchema()` **already** permitted the sentinels — its `wlField` had the exact `anyOf` being added here. The tool
  never loads the schema file (it runs from `file://`, where `fetch` is blocked) and re-implements it in JavaScript instead.

  So the tool was validating records the published schema rejected, and this fix converges **the schema to the tool**, not the reverse. The only edit to `CIEmetaDB.html` is the comment
  that documented the divergence: 2 insertions, 1 deletion. `APP.VERSION` and `ENUMS` are untouched.

  `funderIdentifierType` was deliberately *not* added to `ENUMS`: the tool has no funding form, so it would be dead code.

  ## Verification

  - Schema **parses unaided** — no comment stripping, and it is a valid draft-07 schema.
  - **All 39 published records** in `CIEmetaDBdataset.json` validate against the file.
  - **Regression demonstrated, not claimed**: `CIE_max_sle_mesopic` asserted at 6 errors against the old schema and 0 against the new one.
  - **Still additive**: `CIE_cc_1931_2deg` with `unitPID`/`quantityPID`/`symbol` added still validates.
  - **Parity check**: the schema's sentinel enum is asserted equal to the WebTool's, so the two cannot silently drift again.
  - WebTool JS passes `node --check`.

  ## Also in this PR

  - `v4/docs/README.md` — a "Version 4.1 – schema file corrections" entry. The version stays 4.1; `4.2` is left free for the semantic-annotation phase the advisory proposes.
  - `v4/docs/INTEROPERABILITY.md` — drops its schema-file defect table, which is now history rather than advice. The maintenance risk that let the drift go unnoticed is kept as a note.

  ## Known issue not addressed here

  **The schema is defined twice** — the JSON file and `CIEmetaDB.html` (`ENUMS`, `buildCieSchema()`). That duplication is what let this drift go unnoticed, and it still holds. Inlining
  the schema at build time, or a CI check that fails when the two diverge, would remove the class of defect rather than this instance. Flagged in `INTEROPERABILITY.md` § 10.1.